### PR TITLE
Add GetTuples to SparseMatrix

### DIFF
--- a/dense.go
+++ b/dense.go
@@ -72,6 +72,10 @@ func (A *DenseMatrix) Get(i int, j int) (v float64) {
 	return
 }
 
+func (A *DenseMatrix) GetTuples(row int) []IndexedValue {
+	panic("not implemented")
+}
+
 /*
 Set the element in the ith row and jth column to v.
 */

--- a/matrix.go
+++ b/matrix.go
@@ -36,6 +36,9 @@ type MatrixRO interface {
 	//The element in the ith row and jth column.
 	Get(i, j int) float64
 
+	//The non zero elements of given row in row-col-val tuples
+	GetTuples(row int) []IndexedValue
+
 	Plus(MatrixRO) (Matrix, error)
 	Minus(MatrixRO) (Matrix, error)
 	Times(MatrixRO) (Matrix, error)
@@ -50,6 +53,12 @@ type MatrixRO interface {
 
 	DenseMatrix() *DenseMatrix
 	SparseMatrix() *SparseMatrix
+}
+
+type IndexedValue struct {
+	Row int
+	Col int
+	Val float64
 }
 
 /*

--- a/matrix.go
+++ b/matrix.go
@@ -36,7 +36,7 @@ type MatrixRO interface {
 	//The element in the ith row and jth column.
 	Get(i, j int) float64
 
-	//The non zero elements of given row in row-col-val tuples
+	//The non-zero elements of given row in row-col-val tuples
 	GetTuples(row int) []IndexedValue
 
 	Plus(MatrixRO) (Matrix, error)

--- a/pivot.go
+++ b/pivot.go
@@ -29,6 +29,10 @@ func (P *PivotMatrix) Get(i, j int) float64 {
 	return 0
 }
 
+func (P *PivotMatrix) GetTuples(row int) []IndexedValue {
+	panic("not implemented")
+}
+
 /*
 Convert this PivotMatrix into a DenseMatrix.
 */

--- a/sparse.go
+++ b/sparse.go
@@ -32,6 +32,10 @@ func (A *SparseMatrix) Get(i, j int) float64 {
 	return x
 }
 
+func (A *SparseMatrix) GetTuples(row int) []IndexedValue {
+	panic("not implemented")
+}
+
 /*
 Looks up an element given its element index.
 */

--- a/sparse.go
+++ b/sparse.go
@@ -4,7 +4,10 @@
 
 package matrix
 
-import "math/rand"
+import (
+	"math/rand"
+	"sort"
+)
 
 /*
 A sparse matrix based on go's map datastructure.
@@ -33,7 +36,25 @@ func (A *SparseMatrix) Get(i, j int) float64 {
 }
 
 func (A *SparseMatrix) GetTuples(row int) []IndexedValue {
-	panic("not implemented")
+	tuples := []IndexedValue{}
+	for index, value := range A.elements {
+		if isNearlyZero(value) {
+			continue
+		}
+		i, j := A.GetRowColIndex(index)
+		if i == row {
+			tuples = append(tuples, IndexedValue{Row: i, Col: j, Val: value})
+		}
+	}
+
+	sort.Slice(tuples, func(i, j int) bool {
+		if tuples[i].Row == tuples[j].Row {
+			return tuples[i].Col < tuples[j].Col
+		}
+		return tuples[i].Row < tuples[j].Row
+	})
+
+	return tuples
 }
 
 /*

--- a/sparse_test.go
+++ b/sparse_test.go
@@ -185,3 +185,58 @@ func TestStack_Sparse(t *testing.T) {
 		}
 	}
 }
+
+func TestGetTuples_Sparse(t *testing.T) {
+	A := NormalsSparse(4, 4, 16)
+	for row := 0; row < 4; row++ {
+		rowVals := []float64{}
+		for i := 0; i < 4; i++ {
+			val := A.Get(row, i)
+			if isNearlyZero(val) {
+				continue
+			}
+			rowVals = append(rowVals, val)
+		}
+		tuples := A.GetTuples(row)
+		if len(tuples) != len(rowVals) {
+			t.Fail()
+		}
+	}
+}
+
+func BenchmarkGetIterate_Sparse(b *testing.B) {
+	A := NormalsSparse(1, 100000, 16)
+
+	iterateOver := func(m MatrixRO) {
+		for i := 0; i < m.Rows(); i++ {
+			for j := 0; j < m.Cols(); j++ {
+				_ = m.Get(i, j)
+			}
+		}
+	}
+
+	for i := 0; i < b.N; i++ {
+		iterateOver(A)
+	}
+}
+
+func BenchmarkGetTuplesCreate_Sparse(b *testing.B) {
+	A := NormalsSparse(1, 100000, 16)
+	for i := 0; i < b.N; i++ {
+		_ = A.GetTuples(0)
+	}
+}
+
+func BenchmarkGetTuplesIterate_Sparse(b *testing.B) {
+	A := NormalsSparse(1, 100000, 16)
+	tuples := A.GetTuples(0)
+
+	iterateOver := func(t []IndexedValue) {
+		for range t {
+		}
+	}
+
+	for i := 0; i < b.N; i++ {
+		iterateOver(tuples)
+	}
+}

--- a/util.go
+++ b/util.go
@@ -4,7 +4,10 @@
 
 package matrix
 
-import "runtime"
+import (
+	"math"
+	"runtime"
+)
 
 func max(x, y float64) float64 {
 	if x > y {
@@ -83,4 +86,9 @@ func parFor(inputs <-chan box, foo func(i box)) (wait func()) {
 		}
 	}
 	return
+}
+
+func isNearlyZero(f float64) bool {
+	epsilon := 1e-15
+	return math.Abs(f) < epsilon
 }


### PR DESCRIPTION
SparseMatrix internally uses map to store all the values. Iterating over whole matrix and using Get(i, j) to look for all non-zero values is very inefficient in case of large SparseMatrix.

GetTuples returns only non-zero elements from SparseMatrix. It doesn't do any map lookup, instead it just iterates over elements map and returns all the values that are non-zero. Being SparseMatrix, number of elements are going to be very less. So iteration over this small map makes it really fast.