### PR TITLE
GetTuples should handle sub-sparse matrix correctly

### DIFF
--- a/dense.go
+++ b/dense.go
@@ -72,7 +72,7 @@ func (A *DenseMatrix) Get(i int, j int) (v float64) {
 	return
 }
 
-func (A *DenseMatrix) GetTuples(row int) []IndexedValue {
+func (A *DenseMatrix) GetTuples() []IndexedValue {
 	panic("not implemented")
 }
 

--- a/matrix.go
+++ b/matrix.go
@@ -36,8 +36,8 @@ type MatrixRO interface {
 	//The element in the ith row and jth column.
 	Get(i, j int) float64
 
-	//The non-zero elements of given row in row-col-val tuples
-	GetTuples(row int) []IndexedValue
+	//The non-zero elements of given matrix in row-col-val tuples
+	GetTuples() []IndexedValue
 
 	Plus(MatrixRO) (Matrix, error)
 	Minus(MatrixRO) (Matrix, error)

--- a/pivot.go
+++ b/pivot.go
@@ -29,7 +29,7 @@ func (P *PivotMatrix) Get(i, j int) float64 {
 	return 0
 }
 
-func (P *PivotMatrix) GetTuples(row int) []IndexedValue {
+func (P *PivotMatrix) GetTuples() []IndexedValue {
 	panic("not implemented")
 }
 

--- a/sparse.go
+++ b/sparse.go
@@ -94,8 +94,11 @@ func (A *SparseMatrix) GetColIndex(index int) (j int) {
 Turn an element index into a row and column number.
 */
 func (A *SparseMatrix) GetRowColIndex(index int) (i int, j int) {
+	if index < A.offset {
+		panic("invalid index")
+	}
 	i = (index - A.offset) / A.step
-	j = (index - A.offset) % A.step
+	j = (index % A.step) - (A.offset % A.step)
 	return
 }
 

--- a/sparse.go
+++ b/sparse.go
@@ -41,7 +41,13 @@ func (A *SparseMatrix) GetTuples(row int) []IndexedValue {
 		if isNearlyZero(value) {
 			continue
 		}
+		if index < A.offset {
+			continue
+		}
 		i, j := A.GetRowColIndex(index)
+		if i > A.rows || j > A.cols {
+			continue
+		}
 		if i == row {
 			tuples = append(tuples, IndexedValue{Row: i, Col: j, Val: value})
 		}

--- a/sparse.go
+++ b/sparse.go
@@ -35,7 +35,7 @@ func (A *SparseMatrix) Get(i, j int) float64 {
 	return x
 }
 
-func (A *SparseMatrix) GetTuples(row int) []IndexedValue {
+func (A *SparseMatrix) GetTuples() []IndexedValue {
 	tuples := []IndexedValue{}
 	for index, value := range A.elements {
 		if isNearlyZero(value) {
@@ -45,12 +45,10 @@ func (A *SparseMatrix) GetTuples(row int) []IndexedValue {
 			continue
 		}
 		i, j := A.GetRowColIndex(index)
-		if i > A.rows || j > A.cols {
+		if i < 0 || j < 0 || i >= A.rows || j >= A.cols {
 			continue
 		}
-		if i == row {
-			tuples = append(tuples, IndexedValue{Row: i, Col: j, Val: value})
-		}
+		tuples = append(tuples, IndexedValue{Row: i, Col: j, Val: value})
 	}
 
 	sort.Slice(tuples, func(i, j int) bool {

--- a/sparse.go
+++ b/sparse.go
@@ -175,7 +175,7 @@ func (A *SparseMatrix) GetMatrix(i, j, rows, cols int) (subMatrix *SparseMatrix)
 Gets a reference to a column vector.
 */
 func (A *SparseMatrix) GetColVector(j int) *SparseMatrix {
-	return A.GetMatrix(0, j, A.rows, j+1)
+	return A.GetMatrix(0, j, A.rows, 1)
 }
 
 /*

--- a/sparse_test.go
+++ b/sparse_test.go
@@ -186,6 +186,52 @@ func TestStack_Sparse(t *testing.T) {
 	}
 }
 
+func Test_GetRowColIndex(t *testing.T) {
+	A := MakeDenseMatrix([]float64{0, 1, 2, 3, 4, 5, 6, 7, 8}, 3, 3).SparseMatrix()
+	indexRowsCols := map[int][]int{
+		0: []int{0, 0, 0},
+		1: []int{0, 1, 1},
+		2: []int{0, 2, 2},
+		3: []int{1, 0, 3},
+		4: []int{1, 1, 4},
+		5: []int{1, 2, 5},
+		6: []int{2, 0, 6},
+		7: []int{2, 1, 7},
+		8: []int{2, 2, 8},
+	}
+	for k, v := range indexRowsCols {
+		i, j := A.GetRowColIndex(k)
+		if i != v[0] || j != v[1] {
+			t.Fail()
+		}
+		if v[2] != int(A.Get(i, j)) {
+			t.Fail()
+		}
+	}
+
+	A22 := A.GetMatrix(1, 1, 2, 2)
+	fmt.Println("off:", A22.offset, "step:", A22.step, "rows:", A22.rows, "cols:", A22.cols)
+	indexRowsCols = map[int][]int{
+		4: []int{0, 0, 4},
+		5: []int{0, 1, 5},
+		7: []int{1, 0, 7},
+		8: []int{1, 1, 8},
+	}
+	for k, v := range indexRowsCols {
+		i, j := A22.GetRowColIndex(k)
+		if i != v[0] || j != v[1] {
+			fmt.Println(i, j, v[0], v[1])
+			t.Fail()
+		}
+
+		val := int(A22.Get(i, j))
+		if v[2] != val {
+			fmt.Println(val, v[2])
+			t.Fail()
+		}
+	}
+}
+
 func TestGetTuples_Sparse(t *testing.T) {
 	A := NormalsSparse(4, 4, 16)
 	for row := 0; row < 4; row++ {

--- a/sparse_test.go
+++ b/sparse_test.go
@@ -202,6 +202,43 @@ func TestGetTuples_Sparse(t *testing.T) {
 			t.Fail()
 		}
 	}
+
+	B := MakeDenseMatrix([]float64{0, 0, 0, 40, 0, 60, 0, 80, 90}, 3, 3).SparseMatrix()
+	B0 := B.GetRowVector(0)
+	B2 := B.GetRowVector(2)
+	t.Run("should work only within submatrix bounds", func(t *testing.T) {
+		tuples := B0.GetTuples(2)
+		if len(tuples) != 0 {
+			t.Fail()
+		}
+		tuples = B0.GetTuples(3)
+		if len(tuples) != 0 {
+			t.Fail()
+		}
+	})
+
+	t.Run("should return non-zero elements even for submatrix", func(t *testing.T) {
+		tuples := B0.GetTuples(0)
+		if len(tuples) != 0 {
+			t.Fail()
+		}
+
+		tuples = B2.GetTuples(0)
+		if len(tuples) != 2 {
+			t.Fail()
+		}
+
+		v01 := IndexedValue{0, 1, 80}
+		if tuples[0] != v01 {
+			t.Fail()
+		}
+
+		v02 := IndexedValue{0, 2, 90}
+		if tuples[1] != v02 {
+			t.Fail()
+		}
+	})
+
 }
 
 func BenchmarkGetIterate_Sparse(b *testing.B) {

--- a/sparse_test.go
+++ b/sparse_test.go
@@ -210,7 +210,6 @@ func Test_GetRowColIndex(t *testing.T) {
 	}
 
 	A22 := A.GetMatrix(1, 1, 2, 2)
-	fmt.Println("off:", A22.offset, "step:", A22.step, "rows:", A22.rows, "cols:", A22.cols)
 	indexRowsCols = map[int][]int{
 		4: []int{0, 0, 4},
 		5: []int{0, 1, 5},


### PR DESCRIPTION
GetTuples could be called on a submatrix of bigger sparse matrix. It should handle offset and computed row and col indexes correctly so that it doesn't access other elements from parent sparse matrix and generate wrong row/col indexes for tuples.

Some more background of this code change - 

consider [last commit](https://github.com/clyphub/gillnet/commit/39cf7c39fd3fa61f6984e3acd243d78bb2abed9f) from  branch https://github.com/clyphub/gillnet/compare/main-32808-tocplex-noexpand

this is no-expand implementation of ToCPLEX. here we are trying to directly iterate over math constraints and use DecisionVars and ElasticVars sparse matrices to generate CPLEXConstraints.

while testing, we found that this implementation is generating constraints with x and y terms having -ve indexes in their name. see this snippet from lp_mode.lp
```
  c1: \ constraint 1
  \ constraint_id,flight_id,label,value,target_value,min_value,max_value,measurement,reference,is_inelastic
  \ 1,3,flight_id,3,50000,50000,50000,budget,,true
  + 250 x-5
  + 250 x-4
  + 1000 x-3
  + 1000 x-2
  + 1000 x-1
  + 250 x0
  + 250 x1
  + 250 x2
  + 1000 x3
  + 1000 x4
  + 1000 x5
  \ c1: 'constraint_id,flight_id,label,value,target_value,min_value,max_value,measurement,reference,is_inelastic
  \ 1,3,flight_id,3,50000,50000,50000,budget,,true
  \ ' has only zero y terms
  + 0 y0
    >= + 500
```

digging more into it we got to the implementation of `GetTuples` that we call from `writeSparseNonZeroTerms`. thats the problematic code. `GetTuples` implementation doesn't consider offset, x and y limits if a submatrix (or row/col vector) of bigger sparse matrix was used. thats how it starts returning slice of IndexedValues with negative (or out of range) row and col indexes in them.

till this time, because we were expanding matrix and we were creating a copy of xCoeffs and yCoeffs, each matrix was independent. so GetTuples worked fine. but now we are sharing decisionvars and elasticvars matrices so it started failing.

Ref: https://clypdinc.atlassian.net/browse/MAIN-32808