### PR TITLE
make sure that Indices doesn't fail with stricter GetRowColIndex

### DIFF
--- a/sparse.go
+++ b/sparse.go
@@ -137,6 +137,9 @@ func (A *SparseMatrix) Indices() (out chan int) {
 	out = make(chan int)
 	go func(o chan int) {
 		for index := range A.elements {
+			if index < A.offset {
+				continue
+			}
 			i, j := A.GetRowColIndex(index)
 			if 0 <= i && i < A.rows && 0 <= j && j < A.cols {
 				o <- index

--- a/sparse_test.go
+++ b/sparse_test.go
@@ -6,6 +6,7 @@ package matrix
 
 import (
 	"fmt"
+	"sort"
 	"testing"
 )
 
@@ -337,5 +338,21 @@ func BenchmarkGetTuplesIterate_Sparse(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		iterateOver(tuples)
+	}
+}
+
+func Test_Indices(t *testing.T) {
+	A := MakeDenseMatrix([]float64{0, 1, 2, 3, 4, 5, 6, 7, 8}, 3, 3).SparseMatrix()
+	r0 := A.GetMatrix(1, 1, 2, 2)
+	indices := []int{}
+	for v := range r0.Indices() {
+		indices = append(indices, v)
+	}
+	if len(indices) != 4 {
+		t.Fail()
+	}
+	sort.Ints(indices)
+	if indices[0] != 4 && indices[1] != 5 && indices[2] != 7 && indices[3] != 8 {
+		t.Fail()
 	}
 }


### PR DESCRIPTION
Handle `index < offset` case in `Indices` function as well. This is needed to avoid panics.